### PR TITLE
update schedule to leverage best times

### DIFF
--- a/.github/workflows/ci_amd.yaml
+++ b/.github/workflows/ci_amd.yaml
@@ -1,7 +1,8 @@
 name: CI_AMD
 on: 
   schedule:
-    - cron: 0 5,15 */15,16 * *
+  # “At minute 0 past hour 5 and 15 on day-of-month 1 and 16.”
+    - cron: 0 5,15 1,16 * *
   workflow_dispatch:
     inputs:
       envoyTag:


### PR DESCRIPTION
Looking at the envoy release history I think this schedule leverages the most possible advantages for updating cache and building new releases