### PR TITLE
add strip option to bazel build

### DIFF
--- a/.github/workflows/ci_amd.yaml
+++ b/.github/workflows/ci_amd.yaml
@@ -137,7 +137,7 @@ jobs:
             arch: amd64
             bazel_compile_mode: dbg
             bazel_compile_options: "--define boringssl=fips"
-    runs-on: ${{ matrix.distro != 'darwin' && 'ubuntu-18.04' || 'macos-latest' }}
+    runs-on: ${{ matrix.distro != 'darwin' && 'ubuntu-18.04' || 'macos-12' }}
     continue-on-error: false
     steps:
 

--- a/.github/workflows/ci_amd.yaml
+++ b/.github/workflows/ci_amd.yaml
@@ -241,6 +241,7 @@ jobs:
           --experimental_remote_downloader=grpc://${{env.REMOTE_CACHE_SEVER_HOSTNAME}}:9092
           ${{env.BAZEL_CACHE_MODE}}
           ${{matrix.bazel_compile_options}}
+          ${{ matrix.bazel_compile_mode != 'dbg' && '--strip=always' || '--strip=sometimes' }}
         BAZEL_COMPILATION_MODE: ${{matrix.bazel_compile_mode}}
         DOCKER_BUILD_EXTRA_OPTIONS: >-
           --add-host=${{env.REMOTE_CACHE_SEVER_HOSTNAME}}:${{env.REMOTE_CACHE_SEVER_IP}}


### PR DESCRIPTION
Sets explicit option to strip symbols when compiling for Opt & fastbuild, does not strip symbols for dbg compilation.

Reference: https://bazel.build/docs/user-manual#strip
